### PR TITLE
Add broadcast packet to NetServer

### DIFF
--- a/samples/SampleClient/Program.cs
+++ b/samples/SampleClient/Program.cs
@@ -20,7 +20,7 @@ namespace SampleClient
             {
                 while (true)
                 {
-                    string input = /*Console.ReadLine();*/ $"{GenerateRandomString(random.Next(50))} - {i.ToString()}";
+                    string input = Console.ReadLine(); //$"{GenerateRandomString(random.Next(50))} - {i.ToString()}";
 
                     if (input == "quit")
                     {

--- a/samples/SampleServer/Client.cs
+++ b/samples/SampleServer/Client.cs
@@ -26,14 +26,14 @@ namespace SampleServer
         /// <param name="packet"></param>
         public override void HandleMessage(INetPacketStream packet)
         {
-            string value = packet.Read<string>();
+            var value = packet.Read<string>();
 
             Console.WriteLine("Received '{1}' from {0}", this.Id, value);
 
             using (var p = new NetPacket())
             {
                 p.Write(string.Format("OK: '{0}'", value));
-                this.Send(p);
+                this.Server.SendToAll(p);
             }
         }
     }

--- a/src/Ether.Network/Interfaces/INetServer.cs
+++ b/src/Ether.Network/Interfaces/INetServer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Ether.Network.Interfaces
 {
@@ -27,5 +28,18 @@ namespace Ether.Network.Interfaces
         /// </summary>
         /// <param name="clientId">Client unique id</param>
         void DisconnectClient(Guid clientId);
+
+        /// <summary>
+        /// Sends a packet to a list of connected users.
+        /// </summary>
+        /// <param name="users">List of users.</param>
+        /// <param name="packet">Packet to send.</param>
+        void SendTo(IEnumerable<INetUser> users, INetPacketStream packet);
+
+        /// <summary>
+        /// Sends a packet to every connected user.
+        /// </summary>
+        /// <param name="packet">Packet to send.</param>
+        void SendToAll(INetPacketStream packet);
     }
 }

--- a/src/Ether.Network/Interfaces/INetUser.cs
+++ b/src/Ether.Network/Interfaces/INetUser.cs
@@ -1,4 +1,6 @@
-﻿namespace Ether.Network.Interfaces
+﻿using System.Collections.Generic;
+
+namespace Ether.Network.Interfaces
 {
     /// <summary>
     /// Defines the behavior of an Ether.Network connected user.
@@ -6,10 +8,28 @@
     public interface INetUser : INetConnection
     {
         /// <summary>
+        /// Gets the <see cref="INetServer"/> instance the <see cref="INetUser"/> is connected to.
+        /// </summary>
+        INetServer Server { get; }
+
+        /// <summary>
         /// Sends a packet throught the network.
         /// </summary>
         /// <param name="packet">Outgoing packet</param>
         void Send(INetPacketStream packet);
+
+        /// <summary>
+        /// Sends a packet to a list of users.
+        /// </summary>
+        /// <param name="users">List of users</param>
+        /// <param name="packet">Outgoing packet</param>
+        void SendTo(IEnumerable<INetUser> users, INetPacketStream packet);
+
+        /// <summary>
+        /// Sends a packet to all users on the server.
+        /// </summary>
+        /// <param name="packet">Outgoing packet</param>
+        void SendToAll(INetPacketStream packet);
 
         /// <summary>
         /// Handles an incoming message.

--- a/src/Ether.Network/NetUser.cs
+++ b/src/Ether.Network/NetUser.cs
@@ -1,12 +1,16 @@
 ﻿using Ether.Network.Data;
 using Ether.Network.Interfaces;
 using System;
+using System.Collections.Generic;
 
 namespace Ether.Network
 {
     /// <inheritdoc />
     public abstract class NetUser : NetConnection, INetUser
     {
+        /// <inheritdoc />
+        public INetServer Server { get; internal set; }
+
         /// <summary>
         /// Gets the user token.
         /// </summary>
@@ -22,18 +26,23 @@ namespace Ether.Network
         /// </summary>
         protected NetUser()
         {
+            this.Server = null;
             this.Token = new AsyncUserToken();
         }
 
         /// <inheritdoc />
         public virtual void HandleMessage(INetPacketStream packet)
         {
+            // Nothing to do.
         }
 
         /// <inheritdoc />
-        public virtual void Send(INetPacketStream packet)
-        {
-            this.SendAction?.Invoke(this, packet.Buffer);
-        }
+        public virtual void Send(INetPacketStream packet) => this.SendAction?.Invoke(this, packet.Buffer);
+
+        /// <inheritdoc />
+        public void SendTo(IEnumerable<INetUser> users, INetPacketStream packet) => this.Server?.SendTo(users, packet);
+
+        /// <inheritdoc />
+        public void SendToAll(INetPacketStream packet) => this.Server?.SendToAll(packet);
     }
 }


### PR DESCRIPTION
This PR adds:

- `SendTo` method for `INetServer` : This sends a `INetPacketStream` to a `IEnumerable<INetUser>`.
- `SendToAll` method for `INetServer` : This sends a `INetPacketStream` to every connected clients of the server. (Broadcast to all)

Fixes issue #45.