### PR TITLE
Add possibility to block or not the server

### DIFF
--- a/samples/SampleServer/SampleServer.cs
+++ b/samples/SampleServer/SampleServer.cs
@@ -15,6 +15,7 @@ namespace SampleServer
             this.Configuration.MaximumNumberOfConnections = 100;
             this.Configuration.Host = "127.0.0.1";
             this.Configuration.BufferSize = 8;
+            this.Configuration.Blocking = true;
         }
 
         /// <summary>

--- a/src/Ether.Network/NetServer.cs
+++ b/src/Ether.Network/NetServer.cs
@@ -91,7 +91,9 @@ namespace Ether.Network
 
             this.IsRunning = true;
             this._sendQueueTask.Start();
-            this._manualResetEvent.WaitOne();
+
+            if (this.Configuration.Blocking)
+                this._manualResetEvent.WaitOne();
         }
 
         /// <inheritdoc />
@@ -101,7 +103,9 @@ namespace Ether.Network
                 return;
 
             this.IsRunning = false;
-            this._manualResetEvent.Set();
+
+            if (this.Configuration.Blocking)
+                this._manualResetEvent.Set();
         }
 
         /// <inheritdoc />

--- a/src/Ether.Network/NetServerConfiguration.cs
+++ b/src/Ether.Network/NetServerConfiguration.cs
@@ -11,11 +11,21 @@ namespace Ether.Network
     public sealed class NetServerConfiguration
     {
         private readonly INetServer _server;
+        private bool _blocking;
         private int _port;
         private int _backlog;
         private int _bufferSize;
         private int _maximumNumberOfConnections;
         private string _host;
+
+        /// <summary>
+        /// Gets or sets the blocking state of the server.
+        /// </summary>
+        public bool Blocking
+        {
+            get => this._blocking;
+            set => this.SetValue(ref this._blocking, value);
+        }
 
         /// <summary>
         /// Gets or sets the port.
@@ -74,6 +84,7 @@ namespace Ether.Network
         internal NetServerConfiguration(INetServer server)
         {
             this._server = server;
+            this.Blocking = true;
             this.Port = 0;
             this.Host = null;
             this.Backlog = 50;


### PR DESCRIPTION
Add the `Blocking` property to `NetServerConfiguration`. Solves issue #54.

**Default value is: `true`**

When this property is set to `true`, the server is blocked by a `ManualResetEvent` waiting for the call of `NetServer.Stop()` method. 
When `false`, the `NetServer` doesn't wait after the call of `NetServer.Start()`.

### How to set the property

In the constructor of your server implementation, simply set the `Blocking` property of `NetServerConfiguration` object.
```c#
public MyServer()
{
     // ...
     this.Configuration.Blocking = true;
}
```