### PR TITLE
Fix server dispose after one Stop

### DIFF
--- a/src/Ether.Network/Extensions/BlockingCollectionExtensions.cs
+++ b/src/Ether.Network/Extensions/BlockingCollectionExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Concurrent;
+
+namespace Ether.Network.Extensions
+{
+    /// <summary>
+    /// Contains extensions for <see cref="BlockingCollection{T}"/> objects.
+    /// </summary>
+    public static class BlockingCollectionExtensions
+    {
+        /// <summary>
+        /// Clears a <see cref="BlockingCollection{T}"/>.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="blockingCollection"></param>
+        public static void Clear<T>(this BlockingCollection<T> blockingCollection)
+        {
+            if (blockingCollection == null)
+            {
+                throw new ArgumentNullException("blockingCollection");
+            }
+
+            while (blockingCollection.Count > 0)
+            {
+                blockingCollection.TryTake(out _);
+            }
+        }
+    }
+}

--- a/src/Ether.Network/NetConnection.cs
+++ b/src/Ether.Network/NetConnection.cs
@@ -53,7 +53,11 @@ namespace Ether.Network
 
             if (disposing)
             {
-                this.Socket.Dispose();
+                if (this.Socket != null)
+                {
+                    this.Socket.Dispose();
+                    this.Socket = null;
+                }
             }
 
             this._disposedValue = true;

--- a/src/Ether.Network/Utils/SocketAsyncEventArgsPool.cs
+++ b/src/Ether.Network/Utils/SocketAsyncEventArgsPool.cs
@@ -52,6 +52,17 @@ namespace Ether.Network.Utils
         }
 
         /// <summary>
+        /// Clear the pool.
+        /// </summary>
+        public void Clear()
+        {
+            foreach (SocketAsyncEventArgs e in this._socketPool)
+                e.Dispose();
+
+            this._socketPool.Clear();
+        }
+
+        /// <summary>
         /// Disposes resources.
         /// </summary>
         /// <param name="disposing"></param>
@@ -62,10 +73,7 @@ namespace Ether.Network.Utils
 
             if (disposing)
             {
-                foreach (SocketAsyncEventArgs e in this._socketPool)
-                    e.Dispose();
-
-                this._socketPool.Clear();
+                this.Clear();
             }
 
             this._disposedValue = true;


### PR DESCRIPTION
- `Dispose` after `NetServer.Stop` no longer cause `ObjectDisposedException`.
- Clear the `NetServer` internal resources after a `NetServer.Stop` call.
   - Disconnects the clients
   - Disposes the listning socket
- Add `CancellationToken` for sending queue. Cancel the sending queue `Task` on `Dispose`.

Fixes issues of #54 