### PR TITLE
Added IncludeHeader field to IPacketProcessor

### DIFF
--- a/src/Ether.Network/Interfaces/IPacketProcessor.cs
+++ b/src/Ether.Network/Interfaces/IPacketProcessor.cs
@@ -9,6 +9,11 @@
         /// Gets the packet header size.
         /// </summary>
         int HeaderSize { get; }
+        
+        /// <summary>
+        /// Gets a value indicating whether to put the packet header in front of the packet <see cref="INetPacketStream.Buffer"/>.
+        /// </summary>
+        bool IncludeHeader { get; }
 
         /// <summary>
         /// Gets the packet length.

--- a/src/Ether.Network/NetClient.cs
+++ b/src/Ether.Network/NetClient.cs
@@ -184,6 +184,8 @@ namespace Ether.Network
 
                     using (INetPacketStream packet = this.PacketProcessor.CreatePacket(this.PacketProcessor.IncludeHeader ? Token.HeaderData.Concat(buffer).ToArray() : buffer))
                         this.HandleMessage(packet);
+
+                    Token.HeaderData = null;
                 }
                 catch (Exception e)
                 {

--- a/src/Ether.Network/NetClient.cs
+++ b/src/Ether.Network/NetClient.cs
@@ -3,6 +3,7 @@ using Ether.Network.Packets;
 using Ether.Network.Utils;
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -181,7 +182,7 @@ namespace Ether.Network
                     if (buffer == null)
                         continue;
 
-                    using (INetPacketStream packet = this.PacketProcessor.CreatePacket(buffer))
+                    using (INetPacketStream packet = this.PacketProcessor.CreatePacket(this.PacketProcessor.IncludeHeader ? Token.HeaderData.Concat(buffer).ToArray() : buffer))
                         this.HandleMessage(packet);
                 }
                 catch (Exception e)

--- a/src/Ether.Network/NetServer.cs
+++ b/src/Ether.Network/NetServer.cs
@@ -347,6 +347,8 @@ namespace Ether.Network
         {            
             using (INetPacketStream packet = this.PacketProcessor.CreatePacket(this.PacketProcessor.IncludeHeader ? user.Token.HeaderData.Concat(messageData).ToArray() : messageData))
                 user.HandleMessage(packet);
+
+            user.Token.HeaderData = null;
         }
 
         /// <summary>

--- a/src/Ether.Network/NetServer.cs
+++ b/src/Ether.Network/NetServer.cs
@@ -7,6 +7,7 @@ using Ether.Network.Utils;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -342,9 +343,9 @@ namespace Ether.Network
         /// </summary>
         /// <param name="user">Current user</param>
         /// <param name="messageData">Incoming message data</param>
-        private void HandleIncomingMessages(INetUser user, byte[] messageData)
-        {
-            using (INetPacketStream packet = this.PacketProcessor.CreatePacket(messageData))
+        private void HandleIncomingMessages(T user, byte[] messageData)
+        {            
+            using (INetPacketStream packet = this.PacketProcessor.CreatePacket(this.PacketProcessor.IncludeHeader ? user.Token.HeaderData.Concat(messageData).ToArray() : messageData))
                 user.HandleMessage(packet);
         }
 

--- a/src/Ether.Network/Packets/NetPacketProcessor.cs
+++ b/src/Ether.Network/Packets/NetPacketProcessor.cs
@@ -11,6 +11,11 @@ namespace Ether.Network.Packets
         public int HeaderSize => sizeof(int);
 
         /// <summary>
+        /// Gets a value indicating whether the <see cref="NetPacket"/> header should be put in front of the buffer.
+        /// </summary>
+        public bool IncludeHeader => false;
+
+        /// <summary>
         /// Gets the <see cref="NetPacket"/> length size.
         /// </summary>
         /// <param name="buffer">Incoming buffer</param>

--- a/src/Ether.Network/Utils/SocketAsyncUtils.cs
+++ b/src/Ether.Network/Utils/SocketAsyncUtils.cs
@@ -28,10 +28,9 @@ namespace Ether.Network.Utils
                         int messageSize = packetProcessor.GetLength(token.HeaderData);
 
                         token.MessageSize = messageSize - headerSize;
-                        token.HeaderData = null;
                         token.ReceivedHeaderBytesCount = 0;
                     }
-                    else if (token.TotalReceivedDataSize > headerSize && token.HeaderData == null)
+                    else if (token.TotalReceivedDataSize > headerSize)
                     {
                         token.HeaderData = NetUtils.GetPacketBuffer(e.Buffer, dataStartOffset, headerSize);
                         token.DataStartOffset = dataStartOffset + headerSize;


### PR DESCRIPTION
This is, to have the possibility to put the packet header in front of the buffer when the packet gets created. I needed that because I required to be able to check the first byte in the header, if it was some specific value then the packet has a const size due to it being a ping packet, else it has a dynamic sized payload and I return the length of the payload with GetLength. But I needed to send a Pong packet back to server/client and since the time of the Ping is inside the header and since you cant send packets from IPacketProcessor I needed to be able to send Pong in the HandleMessage method.