### PR TITLE
Regorganize project folders

### DIFF
--- a/samples/SampleClient/MyClient.cs
+++ b/samples/SampleClient/MyClient.cs
@@ -1,5 +1,5 @@
-﻿using Ether.Network;
-using Ether.Network.Interfaces;
+﻿using Ether.Network.Client;
+using Ether.Network.Packets;
 using System;
 using System.Net.Sockets;
 

--- a/samples/SampleServer/Client.cs
+++ b/samples/SampleServer/Client.cs
@@ -1,7 +1,6 @@
-﻿using Ether.Network;
-using System;
+﻿using Ether.Network.Common;
 using Ether.Network.Packets;
-using Ether.Network.Interfaces;
+using System;
 
 namespace SampleServer
 {

--- a/samples/SampleServer/SampleServer.cs
+++ b/samples/SampleServer/SampleServer.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network;
+﻿using Ether.Network.Server;
 using System;
 
 namespace SampleServer

--- a/src/Ether.Network/Client/INetClient.cs
+++ b/src/Ether.Network/Client/INetClient.cs
@@ -1,6 +1,7 @@
-﻿using System;
+﻿using Ether.Network.Packets;
+using System;
 
-namespace Ether.Network.Interfaces
+namespace Ether.Network.Client
 {
     /// <summary>
     /// <see cref="INetClient"/> interface.

--- a/src/Ether.Network/Client/NetClient.cs
+++ b/src/Ether.Network/Client/NetClient.cs
@@ -1,4 +1,5 @@
-﻿using Ether.Network.Interfaces;
+﻿using Ether.Network.Common;
+using Ether.Network.Common.Data;
 using Ether.Network.Packets;
 using Ether.Network.Utils;
 using System;
@@ -9,7 +10,7 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Ether.Network
+namespace Ether.Network.Client
 {
     /// <summary>
     /// Managed TCP client.

--- a/src/Ether.Network/Common/Data/AsyncUserToken.cs
+++ b/src/Ether.Network/Common/Data/AsyncUserToken.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Net.Sockets;
-using Ether.Network.Interfaces;
 
-namespace Ether.Network.Data
+namespace Ether.Network.Common.Data
 {
     /// <inheritdoc />
     internal sealed class AsyncUserToken : IAsyncUserToken

--- a/src/Ether.Network/Common/Data/IAsyncUserToken.cs
+++ b/src/Ether.Network/Common/Data/IAsyncUserToken.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net.Sockets;
 
-namespace Ether.Network.Interfaces
+namespace Ether.Network.Common.Data
 {
     /// <summary>
     /// Defines the user's async token that contains all informations about data receiving process.

--- a/src/Ether.Network/Common/Data/MessageData.cs
+++ b/src/Ether.Network/Common/Data/MessageData.cs
@@ -1,7 +1,7 @@
-﻿using Ether.Network.Interfaces;
+﻿using Ether.Network.Common;
 using System;
 
-namespace Ether.Network.Data
+namespace Ether.Network.Common.Data
 {
     /// <summary>
     /// Defines a structure that handles an incoming message.

--- a/src/Ether.Network/Common/INetConnection.cs
+++ b/src/Ether.Network/Common/INetConnection.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net.Sockets;
 
-namespace Ether.Network.Interfaces
+namespace Ether.Network.Common
 {
     /// <summary>
     /// Describes the behavior of a Ether.Network connection

--- a/src/Ether.Network/Common/INetUser.cs
+++ b/src/Ether.Network/Common/INetUser.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using Ether.Network.Packets;
+using Ether.Network.Server;
+using System.Collections.Generic;
 
-namespace Ether.Network.Interfaces
+namespace Ether.Network.Common
 {
     /// <summary>
     /// Defines the behavior of an Ether.Network connected user.

--- a/src/Ether.Network/Common/NetConnection.cs
+++ b/src/Ether.Network/Common/NetConnection.cs
@@ -1,8 +1,7 @@
-﻿using Ether.Network.Interfaces;
-using System;
+﻿using System;
 using System.Net.Sockets;
 
-namespace Ether.Network
+namespace Ether.Network.Common
 {
     /// <summary>
     /// Represents a network connection.

--- a/src/Ether.Network/Common/NetUser.cs
+++ b/src/Ether.Network/Common/NetUser.cs
@@ -1,9 +1,10 @@
-﻿using Ether.Network.Data;
-using Ether.Network.Interfaces;
+﻿using Ether.Network.Common.Data;
+using Ether.Network.Packets;
+using Ether.Network.Server;
 using System;
 using System.Collections.Generic;
 
-namespace Ether.Network
+namespace Ether.Network.Common
 {
     /// <inheritdoc />
     public abstract class NetUser : NetConnection, INetUser

--- a/src/Ether.Network/Packets/INetPacketStream.cs
+++ b/src/Ether.Network/Packets/INetPacketStream.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Ether.Network.Interfaces
+namespace Ether.Network.Packets
 {
     /// <summary>
     /// Ether.Network Packet stream interface.

--- a/src/Ether.Network/Packets/IPacketProcessor.cs
+++ b/src/Ether.Network/Packets/IPacketProcessor.cs
@@ -1,4 +1,4 @@
-﻿namespace Ether.Network.Interfaces
+﻿namespace Ether.Network.Packets
 {
     /// <summary>
     /// Defines the behavior of a <see cref="IPacketProcessor"/>.

--- a/src/Ether.Network/Packets/NetPacketProcessor.cs
+++ b/src/Ether.Network/Packets/NetPacketProcessor.cs
@@ -1,5 +1,4 @@
-﻿using Ether.Network.Interfaces;
-using System.IO;
+﻿using System.IO;
 
 namespace Ether.Network.Packets
 {

--- a/src/Ether.Network/Packets/NetPacketStream.cs
+++ b/src/Ether.Network/Packets/NetPacketStream.cs
@@ -1,5 +1,4 @@
-﻿using Ether.Network.Interfaces;
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 

--- a/src/Ether.Network/Server/INetServer.cs
+++ b/src/Ether.Network/Server/INetServer.cs
@@ -1,7 +1,9 @@
-﻿using System;
+﻿using Ether.Network.Common;
+using Ether.Network.Packets;
+using System;
 using System.Collections.Generic;
 
-namespace Ether.Network.Interfaces
+namespace Ether.Network.Server
 {
     /// <summary>
     /// Provides a simple and scalable TCP server.

--- a/src/Ether.Network/Server/NetServer.cs
+++ b/src/Ether.Network/Server/NetServer.cs
@@ -1,7 +1,7 @@
-﻿using Ether.Network.Data;
+﻿using Ether.Network.Common;
+using Ether.Network.Common.Data;
 using Ether.Network.Exceptions;
 using Ether.Network.Extensions;
-using Ether.Network.Interfaces;
 using Ether.Network.Packets;
 using Ether.Network.Utils;
 using System;
@@ -13,7 +13,7 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Ether.Network
+namespace Ether.Network.Server
 {
     /// <inheritdoc />
     public abstract class NetServer<T> : NetConnection, INetServer where T : NetUser, new()

--- a/src/Ether.Network/Server/NetServerConfiguration.cs
+++ b/src/Ether.Network/Server/NetServerConfiguration.cs
@@ -1,9 +1,8 @@
 ﻿using Ether.Network.Exceptions;
-using Ether.Network.Interfaces;
 using Ether.Network.Utils;
 using System.Net;
 
-namespace Ether.Network
+namespace Ether.Network.Server
 {
     /// <summary>
     /// Provide properties to configuration a <see cref="NetServer{T}"/>.

--- a/src/Ether.Network/Utils/SocketAsyncUtils.cs
+++ b/src/Ether.Network/Utils/SocketAsyncUtils.cs
@@ -1,4 +1,5 @@
-﻿using Ether.Network.Interfaces;
+﻿using Ether.Network.Common.Data;
+using Ether.Network.Packets;
 using System;
 using System.Linq;
 using System.Net.Sockets;

--- a/test/Ether.Network.Tests/NetPacketStreamTest.cs
+++ b/test/Ether.Network.Tests/NetPacketStreamTest.cs
@@ -1,5 +1,4 @@
-﻿using Ether.Network.Interfaces;
-using Ether.Network.Packets;
+﻿using Ether.Network.Packets;
 using Ether.Network.Tests.Helpers;
 using System;
 using System.IO;


### PR DESCRIPTION
This Pull requests reorganizes the project folders. 

- Now, the `NetServer` and everything related to it is placed in the `Ether.Network/Server` folder and has the following namespace : `Ether.Network.Server`. 
- Same goes for `NetClient`.
- The `NetConnection` and `NetUser` are now placed in the `Ether.Network.Common` namespace.
- The `Ether.Network.Interfaces` namespace has been removed

There is the actual structure:
```
Ether.Network
`-- Ether.Network.Client
`---- INetClient
`---- NetClient
`---- NetClientConfiguration
`-- Ether.Network.Server
`---- INetServer
`---- NetServer<T>
`---- NetServerConfiguration
`-- Ether.Network.Packets
`-- Ether.Network.Common
`---- Ether.Network.Common.Data
` ------- IAsyncUserToken
` ------- AsyncUserToken
` ------- MessageData
`---- INetConnection
`---- INetUser
`---- NetConnection
`---- NetUser
`-- Ether.Network.Exceptions
```
Fixes issues #66 