### PR TITLE
Fixes NetClient message handling process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
             - TEST_FRAMEWORK=netcoreapp1.0
         - os: linux
           sudo: required
-          dotnet: 2.0.2
+          dotnet: 2.1.4
           env: 
             - BUILD_FRAMEWORK=netstandard2.0
             - TEST_FRAMEWORK=netcoreapp2.0

--- a/samples/SampleClient/Program.cs
+++ b/samples/SampleClient/Program.cs
@@ -20,7 +20,7 @@ namespace SampleClient
             {
                 while (true)
                 {
-                    string input = Console.ReadLine(); //$"{GenerateRandomString(random.Next(50))} - {i.ToString()}";
+                    string input = /*Console.ReadLine();*/ $"{GenerateRandomString(random.Next(50))} - {i.ToString()}";
 
                     if (input == "quit")
                     {
@@ -39,7 +39,7 @@ namespace SampleClient
                     }
 
                     i++;
-                    Thread.Sleep(25);
+                    Thread.Sleep(500);
                 }
             }
             catch (Exception e)

--- a/src/Ether.Network/Client/NetClient.cs
+++ b/src/Ether.Network/Client/NetClient.cs
@@ -183,10 +183,16 @@ namespace Ether.Network.Client
                     if (buffer == null)
                         continue;
 
-                    using (INetPacketStream packet = this.PacketProcessor.CreatePacket(this.PacketProcessor.IncludeHeader ? Token.HeaderData.Concat(buffer).ToArray() : buffer))
-                        this.HandleMessage(packet);
+                    byte[] packetData = this.PacketProcessor.IncludeHeader
+                        ? this.Token.HeaderData.Concat(buffer).ToArray()
+                        : buffer;
+                    this.Token.HeaderData = null;
 
-                    Token.HeaderData = null;
+                    Task.Run(() =>
+                    {
+                        using (INetPacketStream packet = this.PacketProcessor.CreatePacket(packetData))
+                            this.HandleMessage(packet);
+                    });
                 }
                 catch (Exception e)
                 {

--- a/test/Ether.Network.Tests/Contexts/Echo/MyEchoClient.cs
+++ b/test/Ether.Network.Tests/Contexts/Echo/MyEchoClient.cs
@@ -11,15 +11,23 @@ namespace Ether.Network.Tests.Contexts.Echo
     public class MyEchoClient : NetClient
     {
         private readonly Random _random;
-        
-        public ICollection<string> SendedData { get; private set; }
+        private readonly List<string> _sendedData;
+
+        public ICollection<string> SendedData
+        {
+            get
+            {
+                this._sendedData.Sort(StringComparer.CurrentCulture);
+                return this._sendedData;
+            }    
+        }
 
         public bool ConnectedToServer { get; private set; }
 
         public MyEchoClient(string host, int port, int bufferSize) 
             : base(host, port, bufferSize)
         {
-            this.SendedData = new List<string>();
+            this._sendedData = new List<string>();
             this._random = new Random();
         }
 
@@ -47,7 +55,7 @@ namespace Ether.Network.Tests.Contexts.Echo
         {
             string message = $"{Helper.GenerateRandomString(this._random.Next(50))}";
 
-            this.SendedData.Add(message);
+            this._sendedData.Add(message);
 
             using (var packet = new NetPacket())
             {

--- a/test/Ether.Network.Tests/Contexts/Echo/MyEchoServer.cs
+++ b/test/Ether.Network.Tests/Contexts/Echo/MyEchoServer.cs
@@ -41,18 +41,27 @@ namespace Ether.Network.Tests.Contexts.Echo
 
     public class EchoClient : NetUser
     {
-        public ICollection<string> ReceivedData { get; private set; }
+        private readonly List<string> _receivedData;
+
+        public ICollection<string> ReceivedData
+        {
+            get
+            {
+                this._receivedData.Sort(StringComparer.CurrentCulture);
+                return this._receivedData;
+            }
+        }
 
         public EchoClient()
         {
-            this.ReceivedData = new List<string>();
+            this._receivedData = new List<string>();
         }
 
         public override void HandleMessage(INetPacketStream packet)
         {
-            string receivedString = packet.Read<string>();
+            var receivedString = packet.Read<string>();
 
-            this.ReceivedData.Add(receivedString);
+            this._receivedData.Add(receivedString);
         }
     }
 }

--- a/test/Ether.Network.Tests/NetServerClientEchoTest.cs
+++ b/test/Ether.Network.Tests/NetServerClientEchoTest.cs
@@ -85,7 +85,7 @@ namespace Ether.Network.Tests
                 // Wait for message
                 while (clientFromServer.ReceivedData.Count < messagesToSend)
                     await Task.Delay(10);
-
+                
                 Assert.Equal(client.SendedData.Count, clientFromServer.ReceivedData.Count);
 
                 for (var i = 0; i < messagesToSend; i++)


### PR DESCRIPTION
This PR fixes the `NetClient` message handling process.

Also, it fixes the unit tests, because we assume that the packets are not treat in the same order as we send them.