### PR TITLE
Feature/net client config

### DIFF
--- a/samples/SampleClient/MyClient.cs
+++ b/samples/SampleClient/MyClient.cs
@@ -13,9 +13,11 @@ namespace SampleClient
         /// <param name="host"></param>
         /// <param name="port"></param>
         /// <param name="bufferSize"></param>
-        public MyClient(string host, int port, int bufferSize) 
-            : base(host, port, bufferSize)
+        public MyClient(string host, int port, int bufferSize)
         {
+            this.Configuration.Host = host;
+            this.Configuration.Port = port;
+            this.Configuration.BufferSize = bufferSize;
         }
 
         /// <summary>
@@ -33,7 +35,7 @@ namespace SampleClient
         /// </summary>
         protected override void OnConnected()
         {
-            Console.WriteLine("Connected to {0}", this.Socket.RemoteEndPoint.ToString());
+            Console.WriteLine("Connected to {0}", this.Socket.RemoteEndPoint);
         }
 
         /// <summary>

--- a/samples/SampleClient/Program.cs
+++ b/samples/SampleClient/Program.cs
@@ -5,9 +5,9 @@ using System.Threading;
 
 namespace SampleClient
 {
-    class Program
+    internal class Program
     {
-        static void Main(string[] args)
+        private static void Main()
         {
             var client = new MyClient("127.0.0.1", 4444, 512);
             client.Connect();
@@ -39,7 +39,7 @@ namespace SampleClient
                     }
 
                     i++;
-                    Thread.Sleep(5);
+                    Thread.Sleep(50);
                 }
             }
             catch (Exception e)

--- a/samples/SampleServer/Program.cs
+++ b/samples/SampleServer/Program.cs
@@ -2,9 +2,9 @@
 
 namespace SampleServer
 {
-    class Program
+    internal class Program
     {
-        static void Main(string[] args)
+        private static void Main()
         {
             Console.Title = "Ether.Network Server";
 

--- a/src/Ether.Network/Client/INetClient.cs
+++ b/src/Ether.Network/Client/INetClient.cs
@@ -17,6 +17,11 @@ namespace Ether.Network.Client
         /// Gets the <see cref="INetClient"/> connected state.
         /// </summary>
         bool IsConnected { get; }
+        
+        /// <summary>
+        /// Gets the <see cref="INetClient"/> running state.
+        /// </summary>
+        bool IsRunning { get; }
 
         /// <summary>
         /// Connects to a remote server.

--- a/src/Ether.Network/Client/NetClientConfiguration.cs
+++ b/src/Ether.Network/Client/NetClientConfiguration.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ether.Network.Client
+{
+    /// <summary>
+    /// Provides properties to configure a <see cref="NetClient"/>.
+    /// </summary>
+    public sealed class NetClientConfiguration
+    {
+    }
+}

--- a/src/Ether.Network/Client/NetClientConfiguration.cs
+++ b/src/Ether.Network/Client/NetClientConfiguration.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Net;
+using Ether.Network.Exceptions;
+using Ether.Network.Utils;
 
 namespace Ether.Network.Client
 {
@@ -9,5 +9,68 @@ namespace Ether.Network.Client
     /// </summary>
     public sealed class NetClientConfiguration
     {
+        private readonly INetClient _client;
+        private int _port;
+        private int _bufferSize;
+        private string _host;
+
+        /// <summary>
+        /// Gets or sets the port.
+        /// </summary>
+        public int Port
+        {
+            get => this._port;
+            set => this.SetValue(ref this._port, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the buffer size.
+        /// </summary>
+        public int BufferSize
+        {
+            get => this._bufferSize;
+            set => this.SetValue(ref this._bufferSize, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the connecting host.
+        /// </summary>
+        public string Host
+        {
+            get => this._host;
+            set => this.SetValue(ref this._host, value);
+        }
+
+        /// <summary>
+        /// Gets the listening address.
+        /// </summary>
+        internal IPAddress Address => NetUtils.GetIpAddress(this._host);
+
+        /// <summary>
+        /// Creates a new <see cref="NetClientConfiguration"/> instance.
+        /// </summary>
+        /// <param name="client"></param>
+        internal NetClientConfiguration(INetClient client)
+        {
+            this._client = client;
+            this._bufferSize = 1024;
+            this._port = 0;
+            this._host = null;
+        }
+
+        /// <summary>
+        /// Set the value of a property passed as reference.
+        /// </summary>
+        /// <typeparam name="T">Type</typeparam>
+        /// <param name="container"></param>
+        /// <param name="value"></param>
+        private void SetValue<T>(ref T container, T value)
+        {
+            if (this._client != null && this._client.IsRunning)
+                throw new EtherConfigurationException("Cannot change configuration once the client is running.");
+
+            if (!Equals(container, value))
+                container = value;
+        }
     }
 }

--- a/src/Ether.Network/Packets/NetPacketStream.cs
+++ b/src/Ether.Network/Packets/NetPacketStream.cs
@@ -19,19 +19,13 @@ namespace Ether.Network.Packets
         private readonly BinaryReader _memoryReader;
         private readonly BinaryWriter _memoryWriter;
 
-        /// <summary>
-        /// Gets the <see cref="NetPacketStream"/> size.
-        /// </summary>
+        /// <inheritdoc />
         public int Size => (int)this.Length;
 
-        /// <summary>
-        /// Gets the <see cref="NetPacketStream"/> buffer.
-        /// </summary>
+        /// <inheritdoc />
         public virtual byte[] Buffer => this.GetInternalBuffer();
 
-        /// <summary>
-        /// Gets the current position of the cursor in the packet stream.
-        /// </summary>
+        /// <inheritdoc />
         public new long Position => base.Position;
 
         /// <summary>
@@ -54,11 +48,7 @@ namespace Ether.Network.Packets
             this._state = PacketStateType.Read;
         }
 
-        /// <summary>
-        /// Reads a T value from the packet.
-        /// </summary>
-        /// <typeparam name="T">Type of the value</typeparam>
-        /// <returns>The value read and converted to the type.</returns>
+        /// <inheritdoc />
         public virtual T Read<T>()
         {
             if (this._state != PacketStateType.Read)
@@ -72,12 +62,7 @@ namespace Ether.Network.Packets
             return default(T);
         }
 
-        /// <summary>
-        /// Reads an array of T value from the packet.
-        /// </summary>
-        /// <typeparam name="T">Value type.</typeparam>
-        /// <param name="amount">Amount to read.</param>
-        /// <returns></returns>
+        /// <inheritdoc />
         public virtual T[] Read<T>(int amount)
         {
             if (this._state != PacketStateType.Read)
@@ -97,11 +82,7 @@ namespace Ether.Network.Packets
             return array;
         }
 
-        /// <summary>
-        /// Writes a T value in the packet.
-        /// </summary>
-        /// <typeparam name="T">Value type.</typeparam>
-        /// <param name="value">Value.</param>
+        /// <inheritdoc />
         public void Write<T>(T value)
         {
             if (this._state != PacketStateType.Write)

--- a/src/Ether.Network/Server/NetServer.cs
+++ b/src/Ether.Network/Server/NetServer.cs
@@ -306,11 +306,10 @@ namespace Ether.Network.Server
             {
                 if (!(e.UserToken is NetUser connection))
                     return;
+                
+                SocketAsyncUtils.ReceiveData(e, connection.Token, this.PacketProcessor);
 
-                IAsyncUserToken token = connection.Token;
-                SocketAsyncUtils.ReceiveData(e, token, this.PacketProcessor);
-
-                if (!token.Socket.ReceiveAsync(e))
+                if (!connection.Socket.ReceiveAsync(e))
                     this.ProcessReceive(e);
             }
             else

--- a/src/Ether.Network/Server/NetServerConfiguration.cs
+++ b/src/Ether.Network/Server/NetServerConfiguration.cs
@@ -5,7 +5,7 @@ using System.Net;
 namespace Ether.Network.Server
 {
     /// <summary>
-    /// Provide properties to configuration a <see cref="NetServer{T}"/>.
+    /// Provide properties to configure a <see cref="NetServer{T}"/>.
     /// </summary>
     public sealed class NetServerConfiguration
     {

--- a/test/Ether.Network.Tests/Contexts/Echo/MyEchoClient.cs
+++ b/test/Ether.Network.Tests/Contexts/Echo/MyEchoClient.cs
@@ -19,14 +19,16 @@ namespace Ether.Network.Tests.Contexts.Echo
             {
                 this._sendedData.Sort(StringComparer.CurrentCulture);
                 return this._sendedData;
-            }    
+            }
         }
 
         public bool ConnectedToServer { get; private set; }
 
-        public MyEchoClient(string host, int port, int bufferSize) 
-            : base(host, port, bufferSize)
+        public MyEchoClient(string host, int port, int bufferSize)
         {
+            this.Configuration.Host = host;
+            this.Configuration.Port = port;
+            this.Configuration.BufferSize = bufferSize;
             this._sendedData = new List<string>();
             this._random = new Random();
         }


### PR DESCRIPTION
This PR adds the `NetClientConfiguration` class. It behaves the same as the `NetServerConfiguration`.

To configure a `NetClient`, you just need to call the `Configuration` property:

```c#
public class MyClient : NetClient
{
    public MyClient()
    {
        this.Configuration.Host = "127.0.0.1";
        this.Configuration.Port= 4444;
        this.Configuration.BufferSize= 1024;
    }
}
```