### PR TITLE
Add unit tests about client/server configuration

### DIFF
--- a/src/Ether.Network/Utils/NetUtils.cs
+++ b/src/Ether.Network/Utils/NetUtils.cs
@@ -18,8 +18,11 @@ namespace Ether.Network.Utils
         /// <returns>Parsed <see cref="IPAddress"/>.</returns>
         public static IPAddress GetIpAddress(string ipOrHost)
         {
-            string host = Dns.GetHostAddressesAsync(ipOrHost).Result.First().ToString();
+            if (string.IsNullOrEmpty(ipOrHost))
+                return null;
 
+            string host = Dns.GetHostAddressesAsync(ipOrHost).Result.First().ToString();
+            
             return IPAddress.TryParse(host, out IPAddress address) ? address : null;
         }
 
@@ -34,9 +37,9 @@ namespace Ether.Network.Utils
             IPAddress address = GetIpAddress(ipOrHost);
 
             if (address == null)
-                throw new EtherConfigurationException($"Invalid host or ip address: {ipOrHost}.");
+                throw new EtherConfigurationException($"Invalid host or ip address: '{ipOrHost}'.");
             if (port <= 0)
-                throw new EtherConfigurationException($"Invalid port: {port}");
+                throw new EtherConfigurationException($"Invalid port: '{port}'");
 
             return new IPEndPoint(address, port);
         }

--- a/test/Ether.Network.Tests/Contexts/NetConfig/ConfigClient.cs
+++ b/test/Ether.Network.Tests/Contexts/NetConfig/ConfigClient.cs
@@ -1,0 +1,27 @@
+﻿using System.Net.Sockets;
+using Ether.Network.Client;
+
+namespace Ether.Network.Tests.Contexts.NetConfig
+{
+    public class ConfigClient : NetClient
+    {
+        protected override void OnConnected()
+        {
+        }
+
+        protected override void OnDisconnected()
+        {
+        }
+
+        protected override void OnSocketError(SocketError socketError)
+        {
+        }
+
+        public void SetConfiguration()
+        {
+            this.Configuration.Host = "127.0.0.1";
+            this.Configuration.Port = 4444;
+            this.Configuration.BufferSize = 1024;
+        }
+    }
+}

--- a/test/Ether.Network.Tests/Contexts/NetConfig/ConfigServer.cs
+++ b/test/Ether.Network.Tests/Contexts/NetConfig/ConfigServer.cs
@@ -1,0 +1,37 @@
+﻿using Ether.Network.Common;
+using Ether.Network.Server;
+using System;
+
+namespace Ether.Network.Tests.Contexts.NetConfig
+{
+    public class ConfigServer : NetServer<Client>
+    {
+        protected override void Initialize()
+        {
+        }
+
+        protected override void OnClientConnected(Client connection)
+        {
+        }
+
+        protected override void OnClientDisconnected(Client connection)
+        {
+        }
+
+        protected override void OnError(Exception exception)
+        {
+        }
+
+        public void SetupConfiguration()
+        {
+            this.Configuration.Blocking = false;
+            this.Configuration.Host = "127.0.0.1";
+            this.Configuration.Port = 4444;
+            this.Configuration.BufferSize = 1024;
+        }
+    }
+
+    public class Client : NetUser
+    {
+    }
+}

--- a/test/Ether.Network.Tests/NetClientConfigurationTest.cs
+++ b/test/Ether.Network.Tests/NetClientConfigurationTest.cs
@@ -1,0 +1,72 @@
+﻿using Ether.Network.Exceptions;
+using Ether.Network.Tests.Contexts.NetConfig;
+using System;
+using Xunit;
+
+namespace Ether.Network.Tests
+{
+    public class NetClientConfigurationTest
+    {
+        [Fact]
+        public void StartClientWihtoutConfiguration()
+        {
+            using (var server = new ConfigServer())
+            {
+                server.SetupConfiguration();
+                server.Start();
+
+                using (var client = new ConfigClient())
+                {
+                    Exception ex = Assert.Throws<EtherConfigurationException>(() => client.Connect());
+                    Assert.IsType<EtherConfigurationException>(ex);
+
+                    client.Disconnect();
+                }
+
+                server.Dispose();
+            }
+        }
+
+        [Fact]
+        public void StartClientWithConfiguration()
+        {
+            using (var server = new ConfigServer())
+            {
+                server.SetupConfiguration();
+                server.Start();
+
+                using (var client = new ConfigClient())
+                {
+                    client.SetConfiguration();
+                    client.Connect();
+                    client.Disconnect();
+                }
+
+                server.Dispose();
+            }
+        }
+
+        [Fact]
+        public void SetupClientConfigurationAfterConnected()
+        {
+            using (var server = new ConfigServer())
+            {
+                server.SetupConfiguration();
+                server.Start();
+
+                using (var client = new ConfigClient())
+                {
+                    client.SetConfiguration();
+                    client.Connect();
+
+                    Exception ex = Assert.Throws<EtherConfigurationException>(() => client.SetConfiguration());
+                    Assert.IsType<EtherConfigurationException>(ex);
+
+                    client.Disconnect();
+                }
+
+                server.Dispose();
+            }
+        }
+    }
+}

--- a/test/Ether.Network.Tests/NetServerConfigurationTest.cs
+++ b/test/Ether.Network.Tests/NetServerConfigurationTest.cs
@@ -1,0 +1,65 @@
+﻿using Ether.Network.Exceptions;
+using Ether.Network.Tests.Contexts.NetConfig;
+using System;
+using Xunit;
+
+namespace Ether.Network.Tests
+{
+    public class NetServerConfigurationTest
+    {
+        [Fact]
+        public void StartServerWithoutConfiguration()
+        {
+            using (var server = new ConfigServer())
+            {
+                Exception ex = Assert.Throws<EtherConfigurationException>(() => server.Start());
+
+                Assert.IsType<EtherConfigurationException>(ex);
+
+                server.Stop();
+            }
+        }
+
+        [Fact]
+        public void SetupServerConfigurationBeforeStart()
+        {
+            using (var server = new ConfigServer())
+            {
+                server.SetupConfiguration();
+                server.Start();
+                server.Stop();
+            }
+        }
+
+        [Fact]
+        public void SetupServerConfigurationAfterStart()
+        {
+            using (var server = new ConfigServer())
+            {
+                server.SetupConfiguration();
+                server.Start();
+
+                Exception ex = Assert.Throws<EtherConfigurationException>(() => server.SetupConfiguration());
+
+                Assert.IsType<EtherConfigurationException>(ex);
+
+                server.Stop();
+            }
+        }
+
+        [Fact]
+        public void SetupServerConfigurationAfterStartStop()
+        {
+            using (var server = new ConfigServer())
+            {
+                server.SetupConfiguration();
+                server.Start();
+                server.Stop();
+
+                server.SetupConfiguration();
+                server.Start();
+                server.Stop();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds unit tests about the `NetServer` and `NetClient` configuration setup. (`NetServerConfiguration` and `NetClientConfiguration`)