### PR TITLE
Fixed proper byte concatenation when IncludeHeader = true.

### DIFF
--- a/src/Ether.Network/Utils/SocketAsyncUtils.cs
+++ b/src/Ether.Network/Utils/SocketAsyncUtils.cs
@@ -54,7 +54,7 @@ namespace Ether.Network.Utils
                     if (token.ReceivedMessageBytesCount == token.MessageSize.Value)
                     {
                         byte[] messageData = packetProcessor.IncludeHeader
-                            ? token.HeaderData.Concat(token.HeaderData).ToArray()
+                            ? token.HeaderData.Concat(token.MessageData).ToArray()
                             : token.MessageData;
 
                         token.Reset();


### PR DESCRIPTION
This commit fixes byte concatenation when the IncludeHeader Flag is set to true. The HeaderData was concatenated with the HeaderData instead of MessageData.