### PR TITLE
Change receive process

### DIFF
--- a/src/Ether.Network/Extensions/BlockingCollectionExtensions.cs
+++ b/src/Ether.Network/Extensions/BlockingCollectionExtensions.cs
@@ -17,7 +17,7 @@ namespace Ether.Network.Extensions
         {
             if (blockingCollection == null)
             {
-                throw new ArgumentNullException("blockingCollection");
+                throw new ArgumentNullException(nameof(blockingCollection));
             }
 
             while (blockingCollection.Count > 0)

--- a/src/Ether.Network/Packets/INetPacketStream.cs
+++ b/src/Ether.Network/Packets/INetPacketStream.cs
@@ -35,7 +35,7 @@ namespace Ether.Network.Packets
         /// <typeparam name="T">Value type.</typeparam>
         /// <param name="amount">Amount to read.</param>
         /// <returns>An array of type T.</returns>
-        T[] Read<T>(int amount);
+        T[] ReadArray<T>(int amount);
 
         /// <summary>
         /// Writes a T value in the packet.

--- a/src/Ether.Network/Packets/IPacketProcessor.cs
+++ b/src/Ether.Network/Packets/IPacketProcessor.cs
@@ -16,17 +16,17 @@
         bool IncludeHeader { get; }
 
         /// <summary>
-        /// Gets the packet length.
+        /// Gets the packet message length.
         /// </summary>
-        /// <param name="buffer">Input buffer</param>
-        /// <returns>Packet data length</returns>
-        int GetLength(byte[] buffer);
+        /// <param name="buffer">Header buffer</param>
+        /// <returns>Packet message data length</returns>
+        int GetMessageLength(byte[] buffer);
 
         /// <summary>
-        /// Creates a T packet instance.
+        /// Creates a new <see cref="INetPacketStream"/> packet instance.
         /// </summary>
         /// <param name="buffer">Input buffer</param>
-        /// <returns></returns>
+        /// <returns>New packet</returns>
         INetPacketStream CreatePacket(byte[] buffer);
     }
 }

--- a/src/Ether.Network/Packets/NetPacket.cs
+++ b/src/Ether.Network/Packets/NetPacket.cs
@@ -7,13 +7,13 @@ namespace Ether.Network.Packets
     /// </summary>
     public sealed class NetPacket : NetPacketStream
     {
-        /// <summary>
-        /// Gets the packet buffer.
-        /// </summary>
+        private readonly int HeaderSize = sizeof(int);
+
+        /// <inheritdoc />
         public override byte[] Buffer => this.BuildBuffer();
 
         /// <summary>
-        /// Creates a new NetPacket in write-only mode.
+        /// Creates a new <see cref="NetPacket"/> in write-only mode.
         /// </summary>
         public NetPacket()
         {
@@ -21,7 +21,7 @@ namespace Ether.Network.Packets
         }
 
         /// <summary>
-        /// Creates a new NetPacket in read-only mode.
+        /// Creates a new <see cref="NetPacket"/> in read-only mode.
         /// </summary>
         /// <param name="buffer"></param>
         public NetPacket(byte[] buffer)
@@ -38,7 +38,7 @@ namespace Ether.Network.Packets
             long oldPosition = this.Position;
 
             this.Seek(0, SeekOrigin.Begin);
-            this.Write(this.Size);
+            this.Write(this.Size - HeaderSize);
             this.Seek((int)oldPosition, SeekOrigin.Begin);
 
             return base.Buffer;

--- a/src/Ether.Network/Packets/NetPacketProcessor.cs
+++ b/src/Ether.Network/Packets/NetPacketProcessor.cs
@@ -1,40 +1,20 @@
-﻿using System.IO;
+﻿using System;
+using System.Linq;
 
 namespace Ether.Network.Packets
 {
     internal sealed class NetPacketProcessor : IPacketProcessor
     {
-        /// <summary>
-        /// Gets the <see cref="NetPacket"/> header size.
-        /// </summary>
+        /// <inheritdoc />
         public int HeaderSize => sizeof(int);
 
-        /// <summary>
-        /// Gets a value indicating whether the <see cref="NetPacket"/> header should be put in front of the buffer.
-        /// </summary>
+        /// <inheritdoc />
         public bool IncludeHeader => false;
 
-        /// <summary>
-        /// Gets the <see cref="NetPacket"/> length size.
-        /// </summary>
-        /// <param name="buffer">Incoming buffer</param>
-        /// <returns>Packet length</returns>
-        public int GetLength(byte[] buffer)
-        {
-            var packetLength = 0;
+        /// <inheritdoc />
+        public int GetMessageLength(byte[] buffer) => BitConverter.ToInt32(buffer.Take(HeaderSize).ToArray(), 0);
 
-            using (var memoryStream = new MemoryStream(buffer))
-            using (var binaryReader = new BinaryReader(memoryStream))
-                packetLength = binaryReader.ReadInt32();
-
-            return packetLength;
-        }
-
-        /// <summary>
-        /// Creates a <see cref="NetPacket"/> instance.
-        /// </summary>
-        /// <param name="buffer">Input buffer</param>
-        /// <returns></returns>
+        /// <inheritdoc />
         public INetPacketStream CreatePacket(byte[] buffer) => new NetPacket(buffer);
     }
 }

--- a/src/Ether.Network/Packets/NetPacketStream.cs
+++ b/src/Ether.Network/Packets/NetPacketStream.cs
@@ -63,7 +63,7 @@ namespace Ether.Network.Packets
         }
 
         /// <inheritdoc />
-        public virtual T[] Read<T>(int amount)
+        public virtual T[] ReadArray<T>(int amount)
         {
             if (this._state != PacketStateType.Read)
                 throw new InvalidOperationException("Packet is in write-only mode.");
@@ -83,7 +83,7 @@ namespace Ether.Network.Packets
         }
 
         /// <inheritdoc />
-        public void Write<T>(T value)
+        public virtual void Write<T>(T value)
         {
             if (this._state != PacketStateType.Write)
                 throw new InvalidOperationException("Packet is in read-only mode.");

--- a/src/Ether.Network/Server/NetServer.cs
+++ b/src/Ether.Network/Server/NetServer.cs
@@ -335,8 +335,11 @@ namespace Ether.Network.Server
         /// <param name="messageData">Incoming message data</param>
         private void HandleIncomingMessages(T user, byte[] messageData)
         {
-            using (INetPacketStream packet = this.PacketProcessor.CreatePacket(messageData))
-                user.HandleMessage(packet);
+            Task.Run(() =>
+            {
+                using (INetPacketStream packet = this.PacketProcessor.CreatePacket(messageData))
+                    user.HandleMessage(packet);
+            });
         }
 
         /// <summary>

--- a/src/Ether.Network/Utils/SocketAsyncUtils.cs
+++ b/src/Ether.Network/Utils/SocketAsyncUtils.cs
@@ -34,7 +34,7 @@ namespace Ether.Network.Utils
                 if (token.ReceivedHeaderBytesCount == packetProcessor.HeaderSize && token.HeaderData != null)
                 {
                     if (!token.MessageSize.HasValue)
-                        token.MessageSize = packetProcessor.GetLength(token.HeaderData) - packetProcessor.HeaderSize;
+                        token.MessageSize = packetProcessor.GetMessageLength(token.HeaderData);
                     if (token.MessageSize.Value < 0)
                         throw new InvalidOperationException("Message size cannot be smaller than zero.");
 

--- a/test/Ether.Network.Tests/NetPacketStreamTest.cs
+++ b/test/Ether.Network.Tests/NetPacketStreamTest.cs
@@ -53,7 +53,7 @@ namespace Ether.Network.Tests
             byte[] value = null;
 
             using (INetPacketStream packetStream = new NetPacketStream(StringTestArray))
-                value = packetStream.Read<byte>(StringTestArray.Length);
+                value = packetStream.ReadArray<byte>(StringTestArray.Length);
 
             string convertedValue = Encoding.ASCII.GetString(value);
 


### PR DESCRIPTION
- Rename of `INetPacketProcessor.GetLength` to `INetPacketProcessor.GetMessageLength` : This method returns the message length placed after the header.
- Review receive process to remove the substraction of the `HeaderSize` of the packet.
- Small refactorings