### PR TITLE
Retry on connection failure

### DIFF
--- a/src/Ether.Network/Client/NetClient.cs
+++ b/src/Ether.Network/Client/NetClient.cs
@@ -87,7 +87,7 @@ namespace Ether.Network.Client
             
             if (!IsConnected)
             {
-                if (this.Configuration.RetryMode == ClientRetryOptions.ToLimit)
+                if (this.Configuration.RetryMode == ClientRetryOptions.Limited)
                 {
                     int count = 0;
                     

--- a/src/Ether.Network/Client/NetClient.cs
+++ b/src/Ether.Network/Client/NetClient.cs
@@ -87,16 +87,13 @@ namespace Ether.Network.Client
                 this._autoConnectEvent.WaitOne(Configuration.TimeOut);
 
             SocketError errorCode = connectSocket.SocketError;
-
-            //Did the connection attempt fail?
+            
             if (!IsConnected)
             {
-                //Should we reconnect more than once?
                 if (this.Configuration.RetryMode == ClientRetryOptions.ToLimit)
                 {
                     int count = 0;
-
-                    //Loop until the retry count
+                    
                     while (!IsConnected && count < this.Configuration.MaxRetryAttempts)
                     {
                         if (this.Socket.ConnectAsync(connectSocket))
@@ -108,7 +105,6 @@ namespace Ether.Network.Client
                 }
                 else if (this.Configuration.RetryMode == ClientRetryOptions.Infinite)
                 {
-                    //Loop infinitely while we haven't made a connection
                     while (!IsConnected)
                     {
                         if (this.Socket.ConnectAsync(connectSocket))
@@ -117,8 +113,7 @@ namespace Ether.Network.Client
                         errorCode = connectSocket.SocketError;
                     }
                 }
-
-                //Are we still not connected after possible retry attempts?
+                
                 if (!IsConnected)
                 {
                     this.OnSocketError(errorCode);

--- a/src/Ether.Network/Client/NetClient.cs
+++ b/src/Ether.Network/Client/NetClient.cs
@@ -83,10 +83,7 @@ namespace Ether.Network.Client
             SocketAsyncEventArgs connectSocket = NetUtils.CreateSocketAsync(this.Socket, this.IO_Completed);
             connectSocket.RemoteEndPoint = NetUtils.CreateIpEndPoint(this.Configuration.Host, this.Configuration.Port);
 
-            if (this.Socket.ConnectAsync(connectSocket))
-                this._autoConnectEvent.WaitOne(Configuration.TimeOut);
-
-            SocketError errorCode = connectSocket.SocketError;
+            SocketError errorCode = ConnectSocketToServer(connectSocket);
             
             if (!IsConnected)
             {
@@ -96,10 +93,7 @@ namespace Ether.Network.Client
                     
                     while (!IsConnected && count < this.Configuration.MaxRetryAttempts)
                     {
-                        if (this.Socket.ConnectAsync(connectSocket))
-                            this._autoConnectEvent.WaitOne(Configuration.TimeOut);
-
-                        errorCode = connectSocket.SocketError;
+                        errorCode = ConnectSocketToServer(connectSocket);
                         count++;
                     }
                 }
@@ -107,10 +101,7 @@ namespace Ether.Network.Client
                 {
                     while (!IsConnected)
                     {
-                        if (this.Socket.ConnectAsync(connectSocket))
-                            this._autoConnectEvent.WaitOne(Configuration.TimeOut);
-
-                        errorCode = connectSocket.SocketError;
+                        errorCode = ConnectSocketToServer(connectSocket);
                     }
                 }
                 
@@ -339,6 +330,19 @@ namespace Ether.Network.Client
             this._isDisposed = true;
 
             base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Connects a socket to a server
+        /// </summary>
+        /// <param name="connectSocket">The socket to connect</param>
+        /// <returns>The socket error</returns>
+        private SocketError ConnectSocketToServer(SocketAsyncEventArgs connectSocket)
+        {
+            if (this.Socket.ConnectAsync(connectSocket))
+                this._autoConnectEvent.WaitOne(Configuration.TimeOut);
+
+            return connectSocket.SocketError;
         }
     }
 }

--- a/src/Ether.Network/Client/NetClient.cs
+++ b/src/Ether.Network/Client/NetClient.cs
@@ -87,7 +87,7 @@ namespace Ether.Network.Client
             
             if (!IsConnected)
             {
-                if (this.Configuration.RetryMode == ClientRetryOptions.Limited)
+                if (this.Configuration.RetryMode == NetClientRetryOptions.Limited)
                 {
                     int count = 0;
                     
@@ -97,7 +97,7 @@ namespace Ether.Network.Client
                         count++;
                     }
                 }
-                else if (this.Configuration.RetryMode == ClientRetryOptions.Infinite)
+                else if (this.Configuration.RetryMode == NetClientRetryOptions.Infinite)
                 {
                     while (!IsConnected)
                     {

--- a/src/Ether.Network/Client/NetClientConfiguration.cs
+++ b/src/Ether.Network/Client/NetClientConfiguration.cs
@@ -15,9 +15,9 @@ namespace Ether.Network.Client
         OneTime = 0,
 
         /// <summary>
-        /// The client will try to connect up to the amount of times specified by <see cref="MaxRetryAttempts"/>
+        /// The client will try to connect a specific amount of times
         /// </summary>
-        ToLimit = 1,
+        Limited = 1,
 
         /// <summary>
         /// The client will try infinitely to connect to the server
@@ -76,7 +76,7 @@ namespace Ether.Network.Client
 
         /// <summary>
         /// Gets or sets how the client handles failed connections.
-        /// When using <see cref="ClientRetryOptions.ToLimit"/> set <see cref="MaxRetryAttempts"/>
+        /// When using <see cref="ClientRetryOptions.Limited"/> set <see cref="MaxRetryAttempts"/>
         /// </summary>
         public ClientRetryOptions RetryMode
         {

--- a/src/Ether.Network/Client/NetClientConfiguration.cs
+++ b/src/Ether.Network/Client/NetClientConfiguration.cs
@@ -5,6 +5,27 @@ using Ether.Network.Utils;
 namespace Ether.Network.Client
 {
     /// <summary>
+    /// Options defining how a client will handle a failed connection attempt
+    /// </summary>
+    public enum ClientRetryOptions
+    {
+        /// <summary>
+        /// The client will only try to connect one time
+        /// </summary>
+        OneTime = 0,
+
+        /// <summary>
+        /// The client will try to connect up to the amount of times specified by <see cref="MaxRetryAttempts"/>
+        /// </summary>
+        ToLimit = 1,
+
+        /// <summary>
+        /// The client will try infinitely to connect to the server
+        /// </summary>
+        Infinite = 2
+    }
+
+    /// <summary>
     /// Provides properties to configure a <see cref="NetClient"/>.
     /// </summary>
     public sealed class NetClientConfiguration
@@ -14,6 +35,8 @@ namespace Ether.Network.Client
         private int _bufferSize;
         private string _host;
         private int _timeOut;
+        private ClientRetryOptions _retryMode;
+        private int _maxRetryAttempts;
 
         /// <summary>
         /// Gets or sets the port.
@@ -49,6 +72,25 @@ namespace Ether.Network.Client
         {
             get => this._timeOut;
             set => this.SetValue(ref this._timeOut, value);
+        }
+
+        /// <summary>
+        /// Gets or sets how the client handles failed connections.
+        /// When using <see cref="ClientRetryOptions.ToLimit"/> set <see cref="MaxRetryAttempts"/>
+        /// </summary>
+        public ClientRetryOptions RetryMode
+        {
+            get => this._retryMode;
+            set => this.SetValue(ref this._retryMode, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum number of times the client will try to reconnect to the server
+        /// </summary>
+        public int MaxRetryAttempts
+        {
+            get => this._maxRetryAttempts;
+            set => this.SetValue(ref this._maxRetryAttempts, value);
         }
 
         /// <summary>

--- a/src/Ether.Network/Client/NetClientConfiguration.cs
+++ b/src/Ether.Network/Client/NetClientConfiguration.cs
@@ -109,6 +109,7 @@ namespace Ether.Network.Client
             this._port = 0;
             this._host = null;
             this._timeOut = 5000;
+            this.RetryMode = ClientRetryOptions.OneTime;
         }
 
         /// <summary>

--- a/src/Ether.Network/Client/NetClientConfiguration.cs
+++ b/src/Ether.Network/Client/NetClientConfiguration.cs
@@ -5,27 +5,6 @@ using Ether.Network.Utils;
 namespace Ether.Network.Client
 {
     /// <summary>
-    /// Options defining how a client will handle a failed connection attempt
-    /// </summary>
-    public enum ClientRetryOptions
-    {
-        /// <summary>
-        /// The client will only try to connect one time
-        /// </summary>
-        OneTime = 0,
-
-        /// <summary>
-        /// The client will try to connect a specific amount of times
-        /// </summary>
-        Limited = 1,
-
-        /// <summary>
-        /// The client will try infinitely to connect to the server
-        /// </summary>
-        Infinite = 2
-    }
-
-    /// <summary>
     /// Provides properties to configure a <see cref="NetClient"/>.
     /// </summary>
     public sealed class NetClientConfiguration
@@ -35,7 +14,7 @@ namespace Ether.Network.Client
         private int _bufferSize;
         private string _host;
         private int _timeOut;
-        private ClientRetryOptions _retryMode;
+        private NetClientRetryOptions _retryMode;
         private int _maxRetryAttempts;
 
         /// <summary>
@@ -76,9 +55,9 @@ namespace Ether.Network.Client
 
         /// <summary>
         /// Gets or sets how the client handles failed connections.
-        /// When using <see cref="ClientRetryOptions.Limited"/> set <see cref="MaxRetryAttempts"/>
+        /// When using <see cref="NetClientRetryOptions.Limited"/> set <see cref="MaxRetryAttempts"/>
         /// </summary>
-        public ClientRetryOptions RetryMode
+        public NetClientRetryOptions RetryMode
         {
             get => this._retryMode;
             set => this.SetValue(ref this._retryMode, value);
@@ -109,7 +88,7 @@ namespace Ether.Network.Client
             this._port = 0;
             this._host = null;
             this._timeOut = 5000;
-            this.RetryMode = ClientRetryOptions.OneTime;
+            this.RetryMode = NetClientRetryOptions.OneTime;
         }
 
         /// <summary>

--- a/src/Ether.Network/Client/NetClientRetryOptions.cs
+++ b/src/Ether.Network/Client/NetClientRetryOptions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ether.Network.Client
+{
+    /// <summary>
+    /// Options defining how a <see cref="NetClient"/> will handle a failed connection attempt
+    /// </summary>
+    public enum NetClientRetryOptions
+    {
+        /// <summary>
+        /// The client will only try to connect one time
+        /// </summary>
+        OneTime = 0,
+
+        /// <summary>
+        /// The client will try to connect a specific amount of times
+        /// </summary>
+        Limited = 1,
+
+        /// <summary>
+        /// The client will try infinitely to connect to the server
+        /// </summary>
+        Infinite = 2
+    }
+}


### PR DESCRIPTION
Here's my take on issue #91.
I've added two properties to NetCientConfiguration, the first of which specifies the retry mode of the client should it fail to connect to the server - OneTime, Limited and Infinite (connect once, connect a certain number of times and connect infinitely respectively). The second property specifies the number of times the client should try to reconnect given that the RetryMode is limited.
I've changed NetClient to implement the logic for this, and shifted the socket connection to a new method for simplicity.