### PR TITLE
encoding change. for Non-English speaking Country

### DIFF
--- a/samples/SampleClient/Program.cs
+++ b/samples/SampleClient/Program.cs
@@ -61,7 +61,7 @@ namespace SampleClient
             Console.ReadLine();
         }
 
-        private const string CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        private const string CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789가나다라마바사아자차카타파하";
 
         /// <summary>
         /// Generates a random string.

--- a/src/Ether.Network/Packets/NetPacketMethods.cs
+++ b/src/Ether.Network/Packets/NetPacketMethods.cs
@@ -7,25 +7,29 @@ namespace Ether.Network.Packets
 {
     internal static class NetPacketMethods
     {
-        /// <summary>
-        /// Read methods dictionary.
-        /// </summary>
-        internal static readonly Dictionary<Type, Func<BinaryReader, object>> ReadMethods = new Dictionary<Type, Func<BinaryReader, object>>
-        {
-            { typeof(char), reader => reader.ReadChar() },
-            { typeof(byte), reader => reader.ReadByte() },
-            { typeof(sbyte), reader => reader.ReadSByte() },
-            { typeof(bool), reader => reader.ReadBoolean()},
-            { typeof(ushort), reader => reader.ReadUInt16()},
-            { typeof(short), reader => reader.ReadInt16()},
-            { typeof(uint), reader => reader.ReadUInt32()},
-            { typeof(int), reader => reader.ReadInt32()},
-            { typeof(ulong), reader => reader.ReadUInt64()},
-            { typeof(long), reader => reader.ReadInt64()},
-            { typeof(float), reader => reader.ReadSingle() },
-            { typeof(double), reader => reader.ReadDouble() },
-            { typeof(byte[]), reader => reader.ReadBytes(count: reader.ReadInt32()) },
-            { typeof(string), reader => new string(reader.ReadChars(count: reader.ReadInt32())) },
+		/// <summary>
+		/// Read methods dictionary.
+		/// </summary>
+		internal static readonly Dictionary<Type, Func<BinaryReader, object>> ReadMethods = new Dictionary<Type, Func<BinaryReader, object>>
+		{
+			{ typeof(char), reader => reader.ReadChar() },
+			{ typeof(byte), reader => reader.ReadByte() },
+			{ typeof(sbyte), reader => reader.ReadSByte() },
+			{ typeof(bool), reader => reader.ReadBoolean()},
+			{ typeof(ushort), reader => reader.ReadUInt16()},
+			{ typeof(short), reader => reader.ReadInt16()},
+			{ typeof(uint), reader => reader.ReadUInt32()},
+			{ typeof(int), reader => reader.ReadInt32()},
+			{ typeof(ulong), reader => reader.ReadUInt64()},
+			{ typeof(long), reader => reader.ReadInt64()},
+			{ typeof(float), reader => reader.ReadSingle() },
+			{ typeof(double), reader => reader.ReadDouble() },
+			{ typeof(byte[]), reader => reader.ReadBytes(count: reader.ReadInt32()) },
+			{ typeof(string), reader => {
+				byte[] tmp = reader.ReadBytes(count: reader.ReadInt32());
+				return Encoding.UTF8.GetString(tmp);
+				}
+			},
         };
 
         /// <summary>
@@ -55,10 +59,14 @@ namespace Ether.Network.Packets
             { typeof(string),
                 (writer, value) =>
                 {
-                    writer.Write(value.ToString().Length);
-                    if (value.ToString().Length > 0)
-                        writer.Write(Encoding.ASCII.GetBytes(value.ToString()));
-                }
+					byte[] enc = Encoding.UTF8.GetBytes(value.ToString());
+
+					if (enc.Length > 0)
+					{
+						writer.Write(enc.Length);
+						writer.Write(enc);
+					}
+				}
             }
         };
     }

--- a/test/Ether.Network.Tests/Helpers/StringGenerator.cs
+++ b/test/Ether.Network.Tests/Helpers/StringGenerator.cs
@@ -6,13 +6,13 @@ namespace Ether.Network.Tests.Helpers
     public static class Helper
     {
         private const string Characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-
-        /// <summary>
-        /// Generates a random string.
-        /// </summary>
-        /// <param name="count">Length of the string.</param>
-        /// <returns>Generated string</returns>
-        public static string GenerateRandomString(int count = 8)
+		private const string CharactersAll = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789가나다라마바사아자차카타파하申東明";
+		/// <summary>
+		/// Generates a random string.
+		/// </summary>
+		/// <param name="count">Length of the string.</param>
+		/// <returns>Generated string</returns>
+		public static string GenerateRandomString(int count = 8)
         {
             var random = new Random();
 
@@ -21,5 +21,15 @@ namespace Ether.Network.Tests.Helpers
                           .Select(s => s[random.Next(s.Length)])
                           .ToArray());
         }
+
+		public static string GenerateRandomStringAllCharacter(int count = 8)
+		{
+			var random = new Random();
+
+			return new string(
+				Enumerable.Repeat(CharactersAll, count)
+						  .Select(s => s[random.Next(s.Length)])
+						  .ToArray());
+		}
     }
 }

--- a/test/Ether.Network.Tests/NetPacketStreamTest.cs
+++ b/test/Ether.Network.Tests/NetPacketStreamTest.cs
@@ -13,13 +13,13 @@ namespace Ether.Network.Tests
         private static readonly short ShortValue = 30546;
         private static readonly int Int32Value = 452674652;
         private static readonly long Int64Value = 3465479740298342;
-        private static readonly string StringValue = Helper.GenerateRandomString(543);
-
+        private static readonly string StringValue = Helper.GenerateRandomStringAllCharacter(543);
+		
         private static readonly byte[] ByteTestArray = new byte[] { ByteValue };
         private static readonly byte[] ShortTestArray = BitConverter.GetBytes(ShortValue);
         private static readonly byte[] Int32TestArray = BitConverter.GetBytes(Int32Value);
         private static readonly byte[] Int64TestArray = BitConverter.GetBytes(Int64Value);
-        private static readonly byte[] StringTestArray = Encoding.ASCII.GetBytes(StringValue);
+        private static readonly byte[] StringTestArray = Encoding.UTF8.GetBytes(StringValue);
 
         private static readonly byte[] ByteArrayValue = BitConverter.GetBytes(0xDEADBEEF);
 
@@ -55,10 +55,11 @@ namespace Ether.Network.Tests
             using (INetPacketStream packetStream = new NetPacketStream(StringTestArray))
                 value = packetStream.ReadArray<byte>(StringTestArray.Length);
 
-            string convertedValue = Encoding.ASCII.GetString(value);
+            string convertedValue = Encoding.UTF8.GetString(value);
 
-            Assert.Equal(StringValue, convertedValue);
+			Assert.Equal(StringValue, convertedValue);
         }
+
 
         [Fact]
         public void ReadByteArray()
@@ -127,7 +128,7 @@ namespace Ether.Network.Tests
 
             Assert.Equal(StringValue, readString);
         }
-
+		
         [Fact]
         public void WriteByteArray()
         {


### PR DESCRIPTION
Korea using alphabet and hanguel

encoding to utf8 before write string size and then write size, write bytes
this operation(or step) is more clearer in other system communication 


